### PR TITLE
Switch to using the Display trait for to_string()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "rust-codegen"
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT"
 authors = ["Robert Corponoi <robertcorponoi@gmail.com"]
 description = "A simple builder API for generating Rust code"
 documentation = "https://docs.rs/rust-codegen/latest/rust_codegen/"
 homepage = "https://github.com/robertcorponoi/rust-codegen"
-repository  = "https://github.com/robertcorponoi/rust-codegen"
-edition = "2018"
+repository = "https://github.com/robertcorponoi/rust-codegen"
+edition = "2021"
+rust-version = "1.63.0"
 
 [dependencies]
-indexmap = "1.9.3"
+indexmap = "2.4.0"

--- a/src/associated_type.rs
+++ b/src/associated_type.rs
@@ -7,25 +7,22 @@ pub struct AssociatedType(pub Bound);
 
 impl AssociatedType {
     /// Add a bound to the associated type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The associated type's bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{AssociatedType, Trait};
-    /// 
+    ///
     /// let mut trait_foo = Trait::new("Foo");
     /// let mut trait_bar = Trait::new("Bar");
-    /// 
+    ///
     /// trait_bar.associated_type("A").bound("Foo");
     /// ```
-    pub fn bound<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.0.bound.push(ty.into());
         self
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Write};
 
 use crate::body::Body;
 use crate::formatter::Formatter;
+use crate::FormatCode;
 
 /// Defines a code block. This is used to define a function body.
 #[derive(Debug, Clone)]
@@ -97,7 +98,8 @@ impl Block {
         self.after = Some(after.to_string());
         self
     }
-
+}
+impl FormatCode for Block {
     /// Formats the block using the given formatter.
     ///
     /// # Arguments
@@ -107,15 +109,15 @@ impl Block {
     /// # Examples
     ///
     /// ```
-    /// use rust_codegen::{Block, Formatter};
+    /// use rust_codegen::*;
     ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
     ///
     /// let mut block = Block::new("This is before");
-    /// block.fmt(&mut fmt);
+    /// block.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         if let Some(ref before) = self.before {
             write!(fmt, "{}", before)?;
         }
@@ -130,7 +132,7 @@ impl Block {
 
         fmt.indent(|fmt| {
             for b in &self.body {
-                b.fmt(fmt)?;
+                b.fmt_code(fmt)?;
             }
 
             Ok(())

--- a/src/block.rs
+++ b/src/block.rs
@@ -16,16 +16,16 @@ pub struct Block {
 
 impl Block {
     /// Returns an empty code block.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `before` - The contents to add before the block. This can be an empty "" if you don't want anything before the block.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Block;
-    /// 
+    ///
     /// let mut block = Block::new("");
     /// ```
     pub fn new(before: &str) -> Self {
@@ -37,44 +37,41 @@ impl Block {
     }
 
     /// Push a line to the code block.
-    /// 
-    /// # Arguments 
-    /// 
+    ///
+    /// # Arguments
+    ///
     /// * `line` - The line to add to the code block.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Block;
-    /// 
+    ///
     /// let mut block = Block::new("");
     /// block.line("println!(\"Hello, world!\");");
     /// ```
-    pub fn line<T>(&mut self, line: T) -> &mut Self
-    where
-        T: ToString,
-    {
+    pub fn line(&mut self, line: impl ToString) -> &mut Self {
         self.body.push(Body::String(line.to_string()));
         self
     }
 
     /// Push a nested block to this block.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `block` - The block to push to this block.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Block;
-    /// 
+    ///
     /// let mut block_1 = Block::new("");
     /// block_1.line("println!(\"Hello, world!\");");
-    /// 
+    ///
     /// let mut block_2 = Block::new("");
     /// block_2.line("println!(\"from Rust!!\");");
-    /// 
+    ///
     /// block_1.push_block(block_2);
     /// ```
     pub fn push_block(&mut self, block: Block) -> &mut Self {
@@ -83,16 +80,16 @@ impl Block {
     }
 
     /// Add a snippet after the block.
-    /// 
-    /// # Arguments 
-    /// 
+    ///
+    /// # Arguments
+    ///
     /// * `after` - The snippet to add after the code block.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Block;
-    /// 
+    ///
     /// let mut block = Block::new("This is before");
     /// block.after("This is after");
     /// ```
@@ -102,19 +99,19 @@ impl Block {
     }
 
     /// Formats the block using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Block, Formatter};
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut block = Block::new("This is before");
     /// block.fmt(&mut fmt);
     /// ```
@@ -129,7 +126,7 @@ impl Block {
             write!(fmt, " ")?;
         }
 
-        write!(fmt, "{{\n")?;
+        writeln!(fmt, "{{")?;
 
         fmt.indent(|fmt| {
             for b in &self.body {
@@ -145,7 +142,7 @@ impl Block {
             write!(fmt, "{}", after)?;
         }
 
-        write!(fmt, "\n")?;
+        writeln!(fmt)?;
         Ok(())
     }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -20,7 +20,7 @@ impl Body {
     /// * `fmt` - The formatter to use.
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match &self {
-            Body::String(s) => write!(fmt, "{}\n", s),
+            Body::String(s) => writeln!(fmt, "{}", s),
             Body::Block(b) => b.fmt(fmt),
         }
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Write};
 
 use crate::block::Block;
 use crate::formatter::Formatter;
+use crate::FormatCode;
 
 /// Defines the types of content that go in functions and blocks.
 #[derive(Debug, Clone)]
@@ -12,16 +13,16 @@ pub enum Body {
     Block(Block),
 }
 
-impl Body {
+impl FormatCode for Body {
     /// Formats the string or block with the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match &self {
             Body::String(s) => writeln!(fmt, "{}", s),
-            Body::Block(b) => b.fmt(fmt),
+            Body::Block(b) => b.fmt_code(fmt),
         }
     }
 }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use crate::formatter::Formatter;
+use crate::{formatter::Formatter, FormatCode};
 
 /// Used to apply documentation to the module, trait, etc.
 #[derive(Debug, Clone)]
@@ -11,23 +11,24 @@ pub struct Docs {
 
 impl Docs {
     /// Creates new documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `docs` - The docs to add.
     pub fn new(docs: &str) -> Self {
         Docs {
             docs: docs.to_string(),
         }
     }
-
-    /// Formats the documentation using the provided formatter. This will also 
+}
+impl FormatCode for Docs {
+    /// Formats the documentation using the provided formatter. This will also
     /// add the `///` before each line of documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for line in self.docs.lines() {
             writeln!(fmt, "/// {}", line)?;
         }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -29,7 +29,7 @@ impl Docs {
     /// * `fmt` - The formatter to use.
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for line in self.docs.lines() {
-            write!(fmt, "/// {}\n", line)?;
+            writeln!(fmt, "/// {}", line)?;
         }
 
         Ok(())

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -101,10 +101,7 @@ impl Enum {
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.bound("T", "Default");
     /// ```
-    pub fn bound<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.type_def.bound(name, ty);
         self
     }

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -5,6 +5,7 @@ use crate::type_def::TypeDef;
 use crate::variant::Variant;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines an enumeration.
 #[derive(Debug, Clone)]
@@ -15,16 +16,16 @@ pub struct Enum {
 
 impl Enum {
     /// Returns a enum definition with the provided name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the enum.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let foo_enum = Enum::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -35,12 +36,12 @@ impl Enum {
     }
 
     /// Returns a reference to the enum's type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let foo_enum = Enum::new("Foo");
     /// println!("{:?}", foo_enum.ty());
     /// ```
@@ -49,16 +50,16 @@ impl Enum {
     }
 
     /// Set the enum's visibility.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visibility of the enum.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.vis("pub");
     /// ```
@@ -68,16 +69,16 @@ impl Enum {
     }
 
     /// Add a generic to the enum.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the generic.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.generic("T");
     /// ```
@@ -87,17 +88,17 @@ impl Enum {
     }
 
     /// Add a `where` bound to the enum.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the bound.
     /// * `ty` - The type of the bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.bound("T", "Default");
     /// ```
@@ -107,16 +108,16 @@ impl Enum {
     }
 
     /// Set the enum's documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `docs` - The docs to set for the enum.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.doc("Sample Foo enum documentation");
     /// ```
@@ -126,16 +127,16 @@ impl Enum {
     }
 
     /// Add a new type that the enum should derive.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the derive.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.derive("Debug");
     /// ```
@@ -145,16 +146,16 @@ impl Enum {
     }
 
     /// Specify lint attribute to supress a warning or error.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `allow` - The lint attribute to apply.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.allow("dead_code");
     /// ```
@@ -164,16 +165,16 @@ impl Enum {
     }
 
     /// Specify representation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `repr` - The representation to specify.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.repr("C");
     /// ```
@@ -183,16 +184,16 @@ impl Enum {
     }
 
     /// Push a variant to the enum, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the variant.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Enum;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
     /// foo_enum.new_variant("FirstVariant");
     /// ```
@@ -202,18 +203,18 @@ impl Enum {
     }
 
     /// Push a variant to the enum.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The variant to push to the enum.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut foo_enum = Enum::new("Foo");
-    /// 
+    ///
     /// let foo_enum_first_variant = Variant::new("FirstVariant");
     /// foo_enum.push_variant(foo_enum_first_variant);
     /// ```
@@ -221,30 +222,32 @@ impl Enum {
         self.variants.push(item);
         self
     }
+}
 
+impl FormatCode for Enum {
     /// Formats the enum using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let foo_enum = Enum::new("Foo");
-    /// foo_enum.fmt(&mut fmt);
+    /// foo_enum.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         self.type_def.fmt_head("enum", &[], fmt)?;
 
         fmt.block(|fmt| {
             for variant in &self.variants {
-                variant.fmt(fmt)?;
+                variant.fmt_code(fmt)?;
             }
 
             Ok(())

--- a/src/field.rs
+++ b/src/field.rs
@@ -18,23 +18,20 @@ pub struct Field {
 
 impl Field {
     /// Return a field definition with the provided name and type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the field.
     /// * `ty` - The type of the field.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Field;
-    /// 
+    ///
     /// let count_field = Field::new("count", "i32");
     /// ```
-    pub fn new<T>(name: &str, ty: T) -> Self
-    where
-        T: Into<Type>,
-    {
+    pub fn new(name: &str, ty: impl Into<Type>) -> Self {
         Field {
             name: name.into(),
             ty: ty.into(),
@@ -44,16 +41,16 @@ impl Field {
     }
 
     /// Set the field's documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `documentation` - The documentation to set for the field.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Field;
-    /// 
+    ///
     /// let count_field = Field::new("count", "i32").doc(Vec::from(["The number of Foos"]));
     pub fn doc(&mut self, documentation: Vec<&str>) -> &mut Self {
         self.documentation = documentation.iter().map(|doc| doc.to_string()).collect();
@@ -61,16 +58,16 @@ impl Field {
     }
 
     /// Set the field's annotation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `annotation` - The annotation to set for the field.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Field;
-    /// 
+    ///
     /// let count_field = Field::new("count", "i32").annotation(Vec::from(["serde(rename = \"name\")"]));
     pub fn annotation(&mut self, annotation: Vec<&str>) -> &mut Self {
         self.annotation = annotation.iter().map(|ann| ann.to_string()).collect();

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -41,10 +41,7 @@ impl Fields {
     /// 
     /// * `name` - The name of the field.
     /// * `ty` - The type of the field.
-    pub fn named<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn named(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.push_named(Field {
             name: name.to_string(),
             ty: ty.into(),
@@ -58,10 +55,7 @@ impl Fields {
     /// # Arguments
     /// 
     /// * `ty` - The type to push.
-    pub fn tuple<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn tuple(&mut self, ty: impl Into<Type>) -> &mut Self {
         match *self {
             Fields::Empty => {
                 *self = Fields::Tuple(vec![ty.into()]);
@@ -87,17 +81,17 @@ impl Fields {
                     for f in fields {
                         if !f.documentation.is_empty() {
                             for doc in &f.documentation {
-                                write!(fmt, "/// {}\n", doc)?;
+                                writeln!(fmt, "/// {}", doc)?;
                             }
                         }
                         if !f.annotation.is_empty() {
                             for ann in &f.annotation {
-                                write!(fmt, "{}\n", ann)?;
+                                writeln!(fmt, "{}", ann)?;
                             }
                         }
                         write!(fmt, "{}: ", f.name)?;
                         f.ty.fmt(fmt)?;
-                        write!(fmt, ",\n")?;
+                        writeln!(fmt, ",")?;
                     }
 
                     Ok(())

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -4,6 +4,7 @@ use crate::field::Field;
 use crate::formatter::Formatter;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines a set of fields.
 #[derive(Debug, Clone)]
@@ -17,9 +18,9 @@ pub enum Fields {
 
 impl Fields {
     /// Pushed a named field passed in as a `Field` type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `field` - The field to push.
     pub fn push_named(&mut self, field: Field) -> &mut Self {
         match *self {
@@ -36,9 +37,9 @@ impl Fields {
     }
 
     /// Pushes a named field by its name and type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the field.
     /// * `ty` - The type of the field.
     pub fn named(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
@@ -51,9 +52,9 @@ impl Fields {
     }
 
     /// Pushes a type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The type to push.
     pub fn tuple(&mut self, ty: impl Into<Type>) -> &mut Self {
         match *self {
@@ -68,11 +69,12 @@ impl Fields {
 
         self
     }
-
+}
+impl FormatCode for Fields {
     /// Formats the fields using the provided formatter.
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Fields::Named(ref fields) => {
                 assert!(!fields.is_empty());
@@ -90,7 +92,7 @@ impl Fields {
                             }
                         }
                         write!(fmt, "{}: ", f.name)?;
-                        f.ty.fmt(fmt)?;
+                        f.ty.fmt_code(fmt)?;
                         writeln!(fmt, ",")?;
                     }
 
@@ -106,7 +108,7 @@ impl Fields {
                     if i != 0 {
                         write!(fmt, ", ")?;
                     }
-                    ty.fmt(fmt)?;
+                    ty.fmt_code(fmt)?;
                 }
 
                 write!(fmt, ")")?;

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -19,16 +19,16 @@ pub struct Formatter<'a> {
 
 impl<'a> Formatter<'a> {
     /// Return a new formatter that writes to the given string.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `dst` - The destination of the formatted string.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Formatter;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
     /// ```
@@ -41,17 +41,14 @@ impl<'a> Formatter<'a> {
     }
 
     /// Wrap the given function inside a block.
-    pub fn block<F>(&mut self, f: F) -> fmt::Result
-    where
-        F: FnOnce(&mut Self) -> fmt::Result,
-    {
+    pub fn block(&mut self, f: impl FnOnce(&mut Self) -> fmt::Result) -> fmt::Result {
         if !self.is_start_of_line() {
             write!(self, " ")?;
         }
 
-        write!(self, "{{\n")?;
+        writeln!(self, "{{")?;
         self.indent(f)?;
-        write!(self, "}}\n")?;
+        writeln!(self, "}}")?;
         Ok(())
     }
 
@@ -74,7 +71,7 @@ impl<'a> Formatter<'a> {
     /// Pushes the number of spaces defined for a new line.
     fn push_spaces(&mut self) {
         for _ in 0..self.spaces {
-            self.dst.push_str(" ");
+            self.dst.push(' ');
         }
     }
 }
@@ -86,7 +83,7 @@ impl<'a> fmt::Write for Formatter<'a> {
 
         for line in s.lines() {
             if !first {
-                self.dst.push_str("\n");
+                self.dst.push('\n');
             }
 
             first = false;
@@ -104,7 +101,7 @@ impl<'a> fmt::Write for Formatter<'a> {
         }
 
         if s.as_bytes().last() == Some(&b'\n') {
-            self.dst.push_str("\n");
+            self.dst.push('\n');
         }
 
         Ok(())
@@ -132,17 +129,17 @@ pub fn fmt_generics(generics: &[String], fmt: &mut Formatter<'_>) -> fmt::Result
 /// Format generic bounds.
 pub fn fmt_bounds(bounds: &[Bound], fmt: &mut Formatter<'_>) -> fmt::Result {
     if !bounds.is_empty() {
-        write!(fmt, "\n")?;
+        writeln!(fmt)?;
 
         // Write first bound
         write!(fmt, "where {}: ", bounds[0].name)?;
         fmt_bound_rhs(&bounds[0].bound, fmt)?;
-        write!(fmt, ",\n")?;
+        writeln!(fmt, ",")?;
 
         for bound in &bounds[1..] {
             write!(fmt, "      {}: ", bound.name)?;
             fmt_bound_rhs(&bound.bound, fmt)?;
-            write!(fmt, ",\n")?;
+            writeln!(fmt, ",")?;
         }
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -377,8 +377,12 @@ impl Function {
     ///
     /// This is only used internally.
     pub(crate) fn set_trait(&mut self) -> &mut Self {
+        assert!(
+            self.vis.is_none(),
+            "trait fns do not have visibility modifiers"
+        );
+
         self.is_trait = true;
-        self.vis = None;
         self
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -43,16 +43,16 @@ pub struct Function {
 
 impl Function {
     /// Return a new function definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let foo_fn = Function::new("foo_fn");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -74,16 +74,16 @@ impl Function {
     }
 
     /// Set the function documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `docs` - The docs to set for the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.doc("Sample Foo function documentation.");
     /// ```
@@ -93,16 +93,16 @@ impl Function {
     }
 
     /// Specify lint attribute to supress a warning or error.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `allow` - The lint attribute to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.allow("dead_code");
     /// ```
@@ -112,16 +112,16 @@ impl Function {
     }
 
     /// Set the function visibility.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visiblity to set for the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.vis("pub");
     /// ```
@@ -131,16 +131,16 @@ impl Function {
     }
 
     /// Set whether this function is async or not.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `async` - Indicates whether this function is async or not.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.set_async(true);
     /// ```
@@ -150,16 +150,16 @@ impl Function {
     }
 
     /// Add a generic to the function.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the generic to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.generic("T");
     /// ```
@@ -169,12 +169,12 @@ impl Function {
     }
 
     /// Add `self` as a function argument.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.arg_self();
     /// ```
@@ -184,12 +184,12 @@ impl Function {
     }
 
     /// Add `&self` as a function argument.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.arg_ref_self();
     /// ```
@@ -199,12 +199,12 @@ impl Function {
     }
 
     /// Add `&mut self` as a function argument.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.arg_mut_self();
     /// ```
@@ -214,24 +214,21 @@ impl Function {
     }
 
     /// Add a function argument.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the argument.
     /// * `ty` - The type of the argument.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.arg("name", "&str");
     /// ```
-    pub fn arg<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn arg(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.args.push(Field {
             name: name.to_string(),
             ty: ty.into(),
@@ -246,46 +243,40 @@ impl Function {
     }
 
     /// Set the function return type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The return type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.ret("String");
     /// ```
-    pub fn ret<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn ret(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.ret = Some(ty.into());
         self
     }
 
     /// Add a `where` bound to the function.
-    /// 
-    /// # Arguments 
-    /// 
+    ///
+    /// # Arguments
+    ///
     /// * `name ` - The name of the bound.
     /// * `ty` - The type of the bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.bound("A", "TraitA");
     /// ```
-    pub fn bound<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.bounds.push(Bound {
             name: name.to_string(),
             bound: vec![ty.into()],
@@ -294,23 +285,20 @@ impl Function {
     }
 
     /// Push a line to the function implementation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `line` - The line to add to the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Function;
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.line("println!(\"Hello, world!\")");
     /// ```
-    pub fn line<T>(&mut self, line: T) -> &mut Self
-    where
-        T: ToString,
-    {
+    pub fn line(&mut self, line: impl ToString) -> &mut Self {
         self.body
             .get_or_insert(vec![])
             .push(Body::String(line.to_string()));
@@ -319,11 +307,11 @@ impl Function {
     }
 
     /// Add an attribute to the function.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `attribute` - The attribute to add.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -338,13 +326,13 @@ impl Function {
     }
 
     /// Specify an `extern` ABI for the function.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `abi` - The extern ABI to add.
-    /// 
-    /// # Examples 
-    /// 
+    ///
+    /// # Examples
+    ///
     /// ```
     /// use rust_codegen::Function;
     ///
@@ -357,21 +345,21 @@ impl Function {
     }
 
     /// Push a block to the function implementation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `block` - The block to push to the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
     ///
     /// let mut foo_fn = Function::new("foo_fn");
-    /// 
+    ///
     /// let mut block = Block::new("");
     /// block.line("println!(\"Hello, world!\");");
-    /// 
+    ///
     /// foo_fn.push_block(block);
     /// ```
     pub fn push_block(&mut self, block: Block) -> &mut Self {
@@ -381,20 +369,20 @@ impl Function {
     }
 
     /// Formats the function using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `is_trait` - Indicates whether it is a trait or not.
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_fn = Function::new("foo_fn");
     /// foo_fn.fmt(false, &mut fmt);
     /// ```
@@ -404,11 +392,11 @@ impl Function {
         }
 
         if let Some(ref allow) = self.allow {
-            write!(fmt, "#[allow({})]\n", allow)?;
+            writeln!(fmt, "#[allow({})]", allow)?;
         }
 
         for attr in self.attributes.iter() {
-            write!(fmt, "#[{}]\n", attr)?;
+            writeln!(fmt, "#[{}]", attr)?;
         }
 
         if is_trait {
@@ -470,7 +458,7 @@ impl Function {
                     panic!("impl blocks must define fn bodies");
                 }
 
-                write!(fmt, ";\n")
+                writeln!(fmt, ";")
             }
         }
     }

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -28,22 +28,19 @@ pub struct Impl {
 
 impl Impl {
     /// Returns a new impl definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `target` - The impl's target.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let foo_impl = Impl::new("Foo");
     /// ```
-    pub fn new<T>(target: T) -> Self
-    where
-        T: Into<Type>,
-    {
+    pub fn new(target: impl Into<Type>) -> Self {
         Impl {
             target: target.into(),
             generics: vec![],
@@ -57,18 +54,18 @@ impl Impl {
 
     /// Add a generic to the impl block.
     ///
-    /// This adds the generic for the block (`impl<T>`) and not the target 
+    /// This adds the generic for the block (`impl<T>`) and not the target
     /// type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the generic.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.generic("T");
     /// ```
@@ -78,60 +75,54 @@ impl Impl {
     }
 
     /// Add a generic to the target type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The generic type to add to the target.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.target_generic("T");
     /// ```
-    pub fn target_generic<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn target_generic(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.target.generic(ty);
         self
     }
 
     /// Set the trait that the impl block is implementing.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The trait that the impl block is implementing.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.impl_trait("T");
     /// ```
-    pub fn impl_trait<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn impl_trait(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.impl_trait = Some(ty.into());
         self
     }
 
     /// Add a macro to the impl block (e.g. `"#[async_trait]"`)
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `macro` - The macro to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.r#macro("async_trait");
     /// ```
@@ -141,28 +132,25 @@ impl Impl {
     }
 
     /// Set an associated type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the associated type.
     /// * `ty` - The type of the associated type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut scope = Scope::new();
-    /// 
+    ///
     /// let trait_foo = scope.new_trait("Foo");
     /// let mut impl_bar = Impl::new("Bar");
-    /// 
+    ///
     /// impl_bar.associate_type("A", "Foo");
     /// ```
-    pub fn associate_type<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn associate_type(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.assoc_tys.push(Field {
             name: name.to_string(),
             ty: ty.into(),
@@ -174,23 +162,20 @@ impl Impl {
     }
 
     /// Add a `where` bound to the impl block.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the bound.
     /// * `ty` - The type of the bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.bound("T", "Default");
-    pub fn bound<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.bounds.push(Bound {
             name: name.to_string(),
             bound: vec![ty.into()],
@@ -199,16 +184,16 @@ impl Impl {
     }
 
     /// Push a new function definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Impl;
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.new_fn("bar_fn");
     pub fn new_fn(&mut self, name: &str) -> &mut Function {
@@ -217,19 +202,19 @@ impl Impl {
     }
 
     /// Push a function definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The function definition to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Function,Impl};
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// let bar_fn = Function::new("bar");
-    /// 
+    ///
     /// foo_impl.push_fn(bar_fn);
     pub fn push_fn(&mut self, item: Function) -> &mut Self {
         self.fns.push(item);
@@ -237,25 +222,25 @@ impl Impl {
     }
 
     /// Formats the impl block using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_impl = Impl::new("Foo");
     /// foo_impl.fmt( &mut fmt);
     /// ```
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for m in self.macros.iter() {
-            write!(fmt, "{}\n", m)?;
+            writeln!(fmt, "{}", m)?;
         }
         write!(fmt, "impl")?;
         fmt_generics(&self.generics[..], fmt)?;
@@ -277,13 +262,13 @@ impl Impl {
                 for ty in &self.assoc_tys {
                     write!(fmt, "type {} = ", ty.name)?;
                     ty.ty.fmt(fmt)?;
-                    write!(fmt, ";\n")?;
+                    writeln!(fmt, ";")?;
                 }
             }
 
             for (i, func) in self.fns.iter().enumerate() {
                 if i != 0 || !self.assoc_tys.is_empty() {
-                    write!(fmt, "\n")?;
+                    writeln!(fmt)?;
                 }
 
                 func.fmt(false, fmt)?;

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -6,6 +6,7 @@ use crate::formatter::{fmt_bounds, fmt_generics, Formatter};
 use crate::function::Function;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines an impl block.
 #[derive(Debug, Clone)]
@@ -220,7 +221,8 @@ impl Impl {
         self.fns.push(item);
         self
     }
-
+}
+impl FormatCode for Impl {
     /// Formats the impl block using the given formatter.
     ///
     /// # Arguments
@@ -236,9 +238,9 @@ impl Impl {
     /// let mut fmt = Formatter::new(&mut dest);
     ///
     /// let mut foo_impl = Impl::new("Foo");
-    /// foo_impl.fmt( &mut fmt);
+    /// foo_impl.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for m in self.macros.iter() {
             writeln!(fmt, "{}", m)?;
         }
@@ -247,12 +249,12 @@ impl Impl {
 
         if let Some(ref t) = self.impl_trait {
             write!(fmt, " ")?;
-            t.fmt(fmt)?;
+            t.fmt_code(fmt)?;
             write!(fmt, " for")?;
         }
 
         write!(fmt, " ")?;
-        self.target.fmt(fmt)?;
+        self.target.fmt_code(fmt)?;
 
         fmt_bounds(&self.bounds, fmt)?;
 
@@ -261,7 +263,7 @@ impl Impl {
             if !self.assoc_tys.is_empty() {
                 for ty in &self.assoc_tys {
                     write!(fmt, "type {} = ", ty.name)?;
-                    ty.ty.fmt(fmt)?;
+                    ty.ty.fmt_code(fmt)?;
                     writeln!(fmt, ";")?;
                 }
             }
@@ -271,7 +273,7 @@ impl Impl {
                     writeln!(fmt)?;
                 }
 
-                func.fmt(false, fmt)?;
+                func.fmt_code(fmt)?;
             }
 
             Ok(())

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,10 +1,11 @@
 use crate::function::Function;
 use crate::module::Module;
-
 use crate::r#enum::Enum;
 use crate::r#impl::Impl;
 use crate::r#struct::Struct;
 use crate::r#trait::Trait;
+use crate::FormatCode;
+use std::fmt::Write;
 
 /// The items that can be created with the Scope.
 #[derive(Debug, Clone)]
@@ -16,4 +17,20 @@ pub enum Item {
     Enum(Enum),
     Impl(Impl),
     Raw(String),
+}
+
+impl FormatCode for Item {
+    fn fmt_code(&self, fmt: &mut crate::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Item::Module(ref v) => v.fmt_code(fmt),
+            Item::Struct(ref v) => v.fmt_code(fmt),
+            Item::Function(ref v) => v.fmt_code(fmt),
+            Item::Trait(ref v) => v.fmt_code(fmt),
+            Item::Enum(ref v) => v.fmt_code(fmt),
+            Item::Impl(ref v) => v.fmt_code(fmt),
+            Item::Raw(ref v) => {
+                writeln!(fmt, "{}", v)
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@
 //!
 //! 1. Create a `Scope` instance.
 //! 2. Use the builder API to add elements to the scope.
-//! 3. Call `Scope::to_string()` to get the generated code.
+//! 3. Call `to_string()` method of the `FormatCode` Trait to get the generated code.
 //!
 //! For example:
 //!
 //! ```rust
-//! use rust_codegen::Scope;
+//! use rust_codegen::{Scope, FormatCode};
 //!
 //! let mut scope = Scope::new();
 //!
@@ -61,3 +61,31 @@ pub use r#impl::*;
 pub use r#struct::*;
 pub use r#trait::*;
 pub use r#type::*;
+
+macro_rules! impl_display {
+    ($struct:ty) => {
+        impl std::fmt::Display for $struct {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut my_fmt = crate::formatter::Formatter::new(f);
+                crate::formatter::FormatCode::fmt_code(self, &mut my_fmt)?;
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_display!(Block);
+impl_display!(Enum);
+impl_display!(Function);
+impl_display!(Impl);
+impl_display!(Module);
+impl_display!(Scope);
+impl_display!(Struct);
+impl_display!(Trait);
+impl_display!(Type);
+impl_display!(Variant);
+
+impl_display!(docs::Docs);
+impl_display!(body::Body);
+impl_display!(fields::Fields);
+impl_display!(item::Item);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ mod r#struct;
 mod r#trait;
 mod r#type;
 
-
 pub use associated_type::*;
 pub use block::*;
 pub use field::*;

--- a/src/module.rs
+++ b/src/module.rs
@@ -9,6 +9,7 @@ use crate::r#enum::Enum;
 use crate::r#impl::Impl;
 use crate::r#struct::Struct;
 use crate::r#trait::Trait;
+use crate::FormatCode;
 
 /// Defines a module.
 #[derive(Debug, Clone)]
@@ -26,16 +27,16 @@ pub struct Module {
 
 impl Module {
     /// Return a new, blank module.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the module.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let foo_module = Module::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -48,12 +49,12 @@ impl Module {
     }
 
     /// Returns a mutable reference to the module's scope.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// println!("{:?}", foo_module.scope());
     /// ```
@@ -62,16 +63,16 @@ impl Module {
     }
 
     /// Set the module visibility.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visibility of the module.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.vis("pub");
     /// ```
@@ -82,19 +83,19 @@ impl Module {
 
     /// Import a type into the module's scope.
     ///
-    /// This results in a new `use` statement bein added to the beginning of 
+    /// This results in a new `use` statement bein added to the beginning of
     /// the module.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `path` - The path to the type to import.
     /// * `ty` - The type to import.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.import("rust_codegen", "Module");
     /// ```
@@ -115,16 +116,16 @@ impl Module {
     /// will return the existing definition instead.
     ///
     /// [`get_or_new_module`]: #method.get_or_new_module
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the module.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_module("Bar");
     /// ```
@@ -133,19 +134,19 @@ impl Module {
     }
 
     /// Returns a reference to a module if it is exists in this scope.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the module to get.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_module("Bar");
-    /// 
+    ///
     /// foo_module.get_module("Bar");
     /// ```
     pub fn get_module<Q: ?Sized>(&self, name: &Q) -> Option<&Module>
@@ -156,19 +157,19 @@ impl Module {
     }
 
     /// Returns a mutable reference to a module if it is exists in this scope.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the module to get.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_module("Bar");
-    /// 
+    ///
     /// foo_module.get_module("Bar");
     /// ```
     pub fn get_module_mut<Q: ?Sized>(&mut self, name: &Q) -> Option<&mut Module>
@@ -180,16 +181,16 @@ impl Module {
 
     /// Returns a mutable reference to a module, creating it if it does
     /// not exist.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the module to get or create if it doesn't exist.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.get_or_new_module("Bar");
     /// ```
@@ -209,19 +210,19 @@ impl Module {
     /// return the existing definition instead.
     ///
     /// [`get_or_new_module`]: #method.get_or_new_module
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The module to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_module = Module::new("Bar");
-    /// 
+    ///
     /// foo_module.push_module(bar_module);
     /// ```
     pub fn push_module(&mut self, item: Module) -> &mut Self {
@@ -230,16 +231,16 @@ impl Module {
     }
 
     /// Push a new struct definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the struct to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_struct("Bar");
     /// ```
@@ -248,19 +249,19 @@ impl Module {
     }
 
     /// Push a structure definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The struct definition to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Module,Struct};
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_struct = Struct::new("Bar");
-    /// 
+    ///
     /// foo_module.push_struct(bar_struct);
     /// ```
     pub fn push_struct(&mut self, item: Struct) -> &mut Self {
@@ -269,16 +270,16 @@ impl Module {
     }
 
     /// Push a new function definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the function to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_fn("bar_fn");
     /// ```
@@ -287,19 +288,19 @@ impl Module {
     }
 
     /// Push a function definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The function definition to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Function,Module};
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_fn = Function::new("bar_fn");
-    /// 
+    ///
     /// foo_module.push_fn(bar_fn);
     /// ```
     pub fn push_fn(&mut self, item: Function) -> &mut Self {
@@ -308,16 +309,16 @@ impl Module {
     }
 
     /// Push a new enum definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the enum.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_enum("Bar");
     /// ```
@@ -326,19 +327,19 @@ impl Module {
     }
 
     /// Push an enum definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The enum definition to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Enum,Module};
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_enum = Enum::new("Bar");
-    /// 
+    ///
     /// foo_module.push_enum(bar_enum);
     /// ```
     pub fn push_enum(&mut self, item: Enum) -> &mut Self {
@@ -347,16 +348,16 @@ impl Module {
     }
 
     /// Push a new `impl` block, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `target` - The impl block to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Module;
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// foo_module.new_impl("Bar");
     /// ```
@@ -365,19 +366,19 @@ impl Module {
     }
 
     /// Push an `impl` block.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The impl definition to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Impl,Module};
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_impl = Impl::new("Bar");
-    /// 
+    ///
     /// foo_module.push_impl(bar_impl);
     /// ```
     pub fn push_impl(&mut self, item: Impl) -> &mut Self {
@@ -386,49 +387,51 @@ impl Module {
     }
 
     /// Push a trait definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The trait to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Module,Trait};
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
     /// let mut bar_trait = Trait::new("Bar");
-    /// 
+    ///
     /// foo_module.push_trait(bar_trait);
     /// ```
     pub fn push_trait(&mut self, item: Trait) -> &mut Self {
         self.scope.push_trait(item);
         self
     }
+}
 
+impl FormatCode for Module {
     /// Formats the module using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_module = Module::new("Foo");
-    /// foo_module.fmt(&mut fmt);
+    /// foo_module.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         if let Some(ref vis) = self.vis {
             write!(fmt, "{} ", vis)?;
         }
 
         write!(fmt, "mod {}", self.name)?;
-        fmt.block(|fmt| self.scope.fmt(fmt))
+        fmt.block(|fmt| self.scope.fmt_code(fmt))
     }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -13,6 +13,7 @@ use crate::r#enum::Enum;
 use crate::r#impl::Impl;
 use crate::r#struct::Struct;
 use crate::r#trait::Trait;
+use crate::FormatCode;
 
 /// Defines a scope.
 ///
@@ -224,50 +225,6 @@ impl Scope {
         self
     }
 
-    /// Return a string representation of the scope.
-    #[allow(clippy::inherent_to_string)]
-    pub fn to_string(&self) -> String {
-        let mut ret = String::new();
-
-        self.fmt(&mut Formatter::new(&mut ret)).unwrap();
-
-        // Remove the trailing newline
-        if ret.as_bytes().last() == Some(&b'\n') {
-            ret.pop();
-        }
-
-        ret
-    }
-
-    /// Formats the scope using the given formatter.
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
-        self.fmt_imports(fmt)?;
-
-        if !self.imports.is_empty() {
-            writeln!(fmt)?;
-        }
-
-        for (i, item) in self.items.iter().enumerate() {
-            if i != 0 {
-                writeln!(fmt)?;
-            }
-
-            match *item {
-                Item::Module(ref v) => v.fmt(fmt)?,
-                Item::Struct(ref v) => v.fmt(fmt)?,
-                Item::Function(ref v) => v.fmt(false, fmt)?,
-                Item::Trait(ref v) => v.fmt(fmt)?,
-                Item::Enum(ref v) => v.fmt(fmt)?,
-                Item::Impl(ref v) => v.fmt(fmt)?,
-                Item::Raw(ref v) => {
-                    writeln!(fmt, "{}", v)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     fn fmt_imports(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         // First, collect all visibilities
         let mut visibilities = vec![];
@@ -316,6 +273,26 @@ impl Scope {
                     }
                 }
             }
+        }
+
+        Ok(())
+    }
+}
+
+impl FormatCode for Scope {
+    /// Formats the scope using the given formatter.
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        self.fmt_imports(fmt)?;
+
+        if !self.imports.is_empty() {
+            writeln!(fmt)?;
+        }
+
+        for (i, item) in self.items.iter().enumerate() {
+            if i != 0 {
+                writeln!(fmt)?;
+            }
+            item.fmt_code(fmt)?;
         }
 
         Ok(())

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -6,6 +6,7 @@ use crate::formatter::Formatter;
 use crate::type_def::TypeDef;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines a struct.
 #[derive(Debug, Clone)]
@@ -19,16 +20,16 @@ pub struct Struct {
 
 impl Struct {
     /// Return a structure definition with the provided name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the struct.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let foo_struct = Struct::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -40,12 +41,12 @@ impl Struct {
     }
 
     /// Returns a reference to the type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let foo_struct = Struct::new("Foo");
     /// println!("{:?}", foo_struct.ty());
     /// ```
@@ -54,16 +55,16 @@ impl Struct {
     }
 
     /// Set the structure visibility.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visibility of the struct.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.vis("pub");
     /// ```
@@ -73,16 +74,16 @@ impl Struct {
     }
 
     /// Add a generic to the struct.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the generic.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.generic("T");
     /// ```
@@ -92,17 +93,17 @@ impl Struct {
     }
 
     /// Add a `where` bound to the struct.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the bound.
     /// * `ty` - The type of the bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.bound("A", "TraitA");
     /// ```
@@ -112,16 +113,16 @@ impl Struct {
     }
 
     /// Set the structure documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `docs` - The documentation to set for the struct.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.doc("Sample struct documentation.");
     /// ```
@@ -131,16 +132,16 @@ impl Struct {
     }
 
     /// Add a new type that the struct should derive.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the type to derive.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.derive("Debug");
     /// ```
@@ -150,16 +151,16 @@ impl Struct {
     }
 
     /// Specify lint attribute to supress a warning or error.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `allow` - The lint attribute to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.allow("dead_code");
     /// ```
@@ -169,14 +170,14 @@ impl Struct {
     }
 
     /// Specify representation.
-    /// 
+    ///
     /// * `repr` - The representation to specify.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.repr("C");
     /// ```
@@ -189,19 +190,19 @@ impl Struct {
     ///
     /// A struct can either set named fields with this function or tuple fields
     /// with `push_tuple_field`, but not both.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `field` - The named field to push.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Field,Struct};
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// let mut bar_field = Field::new("bar", "i32");
-    /// 
+    ///
     /// foo_struct.push_field(bar_field);
     /// ```
     pub fn push_field(&mut self, field: Field) -> &mut Self {
@@ -213,17 +214,17 @@ impl Struct {
     ///
     /// A struct can either set named fields with this function or tuple fields
     /// with `tuple_field`, but not both.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the field.
     /// * `ty` - The type of the field.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.field("bar", "i32");
     /// ```
@@ -236,19 +237,19 @@ impl Struct {
     ///
     /// A struct can either set tuple fields with this function or named fields
     /// with `field`, but not both.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The type of the tuple field to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Struct,Type};
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// let mut bar_type = Type::new("bar");
-    /// 
+    ///
     /// foo_struct.tuple_field(bar_type);
     /// ```
     pub fn tuple_field(&mut self, ty: impl Into<Type>) -> &mut Self {
@@ -257,16 +258,16 @@ impl Struct {
     }
 
     /// Adds an attribute to the struct (e.g. `"#[some_attribute]"`)
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `attribute` - The attribute to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Struct;
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.attr("some_attribute");
     /// ```
@@ -274,30 +275,31 @@ impl Struct {
         self.attributes.push(attribute.to_string());
         self
     }
-
+}
+impl FormatCode for Struct {
     /// Formats the struct using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::*;
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_struct = Struct::new("Foo");
-    /// foo_struct.fmt(&mut fmt);
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    /// foo_struct.fmt_code(&mut fmt);
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for m in self.attributes.iter() {
             writeln!(fmt, "{}", m)?;
         }
-        
+
         self.type_def.fmt_head("struct", &[], fmt)?;
-        self.fields.fmt(fmt)?;
+        self.fields.fmt_code(fmt)?;
 
         match self.fields {
             Fields::Empty => {

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -106,10 +106,7 @@ impl Struct {
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.bound("A", "TraitA");
     /// ```
-    pub fn bound<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.type_def.bound(name, ty);
         self
     }
@@ -230,10 +227,7 @@ impl Struct {
     /// let mut foo_struct = Struct::new("Foo");
     /// foo_struct.field("bar", "i32");
     /// ```
-    pub fn field<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn field(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.fields.named(name, ty);
         self
     }
@@ -257,10 +251,7 @@ impl Struct {
     /// 
     /// foo_struct.tuple_field(bar_type);
     /// ```
-    pub fn tuple_field<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn tuple_field(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.fields.tuple(ty);
         self
     }
@@ -302,7 +293,7 @@ impl Struct {
     /// foo_struct.fmt(&mut fmt);
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for m in self.attributes.iter() {
-            write!(fmt, "{}\n", m)?;
+            writeln!(fmt, "{}", m)?;
         }
         
         self.type_def.fmt_head("struct", &[], fmt)?;
@@ -310,10 +301,10 @@ impl Struct {
 
         match self.fields {
             Fields::Empty => {
-                write!(fmt, ";\n")?;
+                writeln!(fmt, ";")?;
             }
             Fields::Tuple(..) => {
-                write!(fmt, ";\n")?;
+                writeln!(fmt, ";")?;
             }
             _ => {}
         }

--- a/src/trait.rs
+++ b/src/trait.rs
@@ -7,6 +7,7 @@ use crate::function::Function;
 use crate::type_def::TypeDef;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines a trait.
 #[allow(dead_code)]
@@ -214,6 +215,7 @@ impl Trait {
     pub fn new_fn(&mut self, name: &str) -> &mut Function {
         let mut func = Function::new(name);
         func.body = None;
+        func.set_trait();
 
         self.push_fn(func);
         self.fns.last_mut().unwrap()
@@ -235,11 +237,13 @@ impl Trait {
     ///
     /// foo_trait.push_fn(bar_fn);
     /// ```
-    pub fn push_fn(&mut self, item: Function) -> &mut Self {
+    pub fn push_fn(&mut self, mut item: Function) -> &mut Self {
+        item.set_trait();
         self.fns.push(item);
         self
     }
-
+}
+impl FormatCode for Trait {
     /// Formats the scope using the given formatter.
     ///
     /// # Arguments
@@ -249,15 +253,15 @@ impl Trait {
     /// # Examples
     ///
     /// ```
-    /// use rust_codegen::{Formatter,Trait};
+    /// use rust_codegen::*;
     ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
     ///
     /// let mut foo_trait = Trait::new("Foo");
-    /// foo_trait.fmt(&mut fmt);
+    /// foo_trait.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         self.type_def.fmt_head("trait", &self.parents, fmt)?;
 
         fmt.block(|fmt| {
@@ -284,7 +288,7 @@ impl Trait {
                     writeln!(fmt)?;
                 }
 
-                func.fmt(true, fmt)?;
+                func.fmt_code(fmt)?;
             }
 
             Ok(())

--- a/src/trait.rs
+++ b/src/trait.rs
@@ -26,16 +26,16 @@ pub struct Trait {
 
 impl Trait {
     /// Return a trait definition with the provided name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the trait.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let foo_trait = Trait::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -49,12 +49,12 @@ impl Trait {
     }
 
     /// Returns a reference to the type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let foo_trait = Trait::new("Foo");
     /// println!("{:?}", foo_trait.ty());
     /// ```
@@ -63,16 +63,16 @@ impl Trait {
     }
 
     /// Set the trait visibility.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visibility to set for the trait.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.vis("pub");
     /// ```
@@ -82,12 +82,12 @@ impl Trait {
     }
 
     /// Add a generic to the trait.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.generic("T");
     /// ```
@@ -97,39 +97,36 @@ impl Trait {
     }
 
     /// Add a `where` bound to the trait.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the bound.
     /// * `ty` - The type of the bound.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.bound("A", "String");
     /// ```
-    pub fn bound<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.type_def.bound(name, ty);
         self
     }
 
     /// Add a macro to the trait def (e.g. `"#[async_trait]"`).
-    /// 
-    /// # Arguments 
-    /// 
+    ///
+    /// # Arguments
+    ///
     /// * `r#macro` - The macro to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.r#macro("async_trait");
     /// ```
@@ -139,38 +136,35 @@ impl Trait {
     }
 
     /// Add a parent trait.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The type of the parent trait.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.parent("Bar");
     /// ```
-    pub fn parent<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn parent(&mut self, ty: impl Into<Type>) -> &mut Self {
         self.parents.push(ty.into());
         self
     }
 
     /// Set the trait documentation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `docs` - The documentation for the trait.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.doc("Sample trait documentation.");
     /// ```
@@ -181,16 +175,16 @@ impl Trait {
 
     /// Add an associated type. Returns a mutable reference to the new
     /// associated type for futher configuration.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the associated type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.associated_type("A");
     /// ```
@@ -204,16 +198,16 @@ impl Trait {
     }
 
     /// Push a new function definition, returning a mutable reference to it.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the function.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Trait;
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.new_fn("bar_fn");
     /// ```
@@ -226,19 +220,19 @@ impl Trait {
     }
 
     /// Push a function definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `item` - The function to add.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Function,Trait};
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// let mut bar_fn = Function::new("bar_fn");
-    /// 
+    ///
     /// foo_trait.push_fn(bar_fn);
     /// ```
     pub fn push_fn(&mut self, item: Function) -> &mut Self {
@@ -247,19 +241,19 @@ impl Trait {
     }
 
     /// Formats the scope using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Formatter,Trait};
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_trait = Trait::new("Foo");
     /// foo_trait.fmt(&mut fmt);
     /// ```
@@ -281,13 +275,13 @@ impl Trait {
                         fmt_bound_rhs(&ty.bound, fmt)?;
                     }
 
-                    write!(fmt, ";\n")?;
+                    writeln!(fmt, ";")?;
                 }
             }
 
             for (i, func) in self.fns.iter().enumerate() {
                 if i != 0 || !assoc.is_empty() {
-                    write!(fmt, "\n")?;
+                    writeln!(fmt)?;
                 }
 
                 func.fmt(true, fmt)?;

--- a/src/type.rs
+++ b/src/type.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use crate::formatter::Formatter;
+use crate::{formatter::Formatter, FormatCode};
 
 /// Defines a type.
 #[derive(Debug, Clone)]
@@ -56,24 +56,6 @@ impl Type {
         self.generics.push(ty.into());
         self
     }
-
-    /// Formats the struct using the given formatter.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rust_codegen::{Formatter,Type};
-    ///
-    /// let mut dest = String::new();
-    /// let mut fmt = Formatter::new(&mut dest);
-    ///
-    /// let mut foo_type = Type::new("Foo");
-    /// foo_type.fmt(&mut fmt);
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.name)?;
-        Type::fmt_slice(&self.generics, fmt)
-    }
-
     /// Formats the type using the given formatter with the given generics.
     ///
     /// # Arguments
@@ -88,13 +70,32 @@ impl Type {
                 if i != 0 {
                     write!(fmt, ", ")?
                 }
-                ty.fmt(fmt)?;
+                ty.fmt_code(fmt)?;
             }
 
             write!(fmt, ">")?;
         }
 
         Ok(())
+    }
+}
+
+impl FormatCode for Type {
+    /// Formats the struct using the given formatter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_codegen::*;
+    ///
+    /// let mut dest = String::new();
+    /// let mut fmt = Formatter::new(&mut dest);
+    ///
+    /// let mut foo_type = Type::new("Foo");
+    /// foo_type.fmt_code(&mut fmt);
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}", self.name)?;
+        Type::fmt_slice(&self.generics, fmt)
     }
 }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -13,16 +13,16 @@ pub struct Type {
 
 impl Type {
     /// Return a new type with the given name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Type;
-    /// 
+    ///
     /// let foo_type = Type::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -33,23 +33,20 @@ impl Type {
     }
 
     /// Add a generic to the type.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The generic to add to the type.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Type;
-    /// 
+    ///
     /// let mut foo_type = Type::new("Foo");
     /// foo_type.generic("T");
     /// ```
-    pub fn generic<T>(&mut self, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn generic(&mut self, ty: impl Into<Type>) -> &mut Self {
         // Make sure that the name doesn't already include generics
         assert!(
             !self.name.contains("<"),
@@ -61,15 +58,15 @@ impl Type {
     }
 
     /// Formats the struct using the given formatter.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Formatter,Type};
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_type = Type::new("Foo");
     /// foo_type.fmt(&mut fmt);
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
@@ -78,9 +75,9 @@ impl Type {
     }
 
     /// Formats the type using the given formatter with the given generics.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `generics` - The generics to use.
     /// * `fmt` - The formatter to use.
     fn fmt_slice(generics: &[Type], fmt: &mut Formatter<'_>) -> fmt::Result {

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -5,6 +5,7 @@ use crate::docs::Docs;
 use crate::formatter::{fmt_bounds, Formatter};
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines a type definition.
 #[derive(Debug, Clone)]
@@ -127,7 +128,7 @@ impl TypeDef {
         fmt: &mut Formatter<'_>,
     ) -> fmt::Result {
         if let Some(ref docs) = self.docs {
-            docs.fmt(fmt)?;
+            docs.fmt_code(fmt)?;
         }
 
         self.fmt_allow(fmt)?;
@@ -140,7 +141,7 @@ impl TypeDef {
         }
 
         write!(fmt, "{} ", keyword)?;
-        self.ty.fmt(fmt)?;
+        self.ty.fmt_code(fmt)?;
 
         if !parents.is_empty() {
             for (i, ty) in parents.iter().enumerate() {
@@ -150,7 +151,7 @@ impl TypeDef {
                     write!(fmt, " + ")?;
                 }
 
-                ty.fmt(fmt)?;
+                ty.fmt_code(fmt)?;
             }
         }
 

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -29,9 +29,9 @@ pub struct TypeDef {
 
 impl TypeDef {
     /// Return a type definition with the provided name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the type definition.
     pub fn new(name: &str) -> Self {
         TypeDef {
@@ -47,24 +47,21 @@ impl TypeDef {
     }
 
     /// Sets the visibility of the type definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `vis` - The visiblity of the type definition.
     pub fn vis(&mut self, vis: &str) {
         self.vis = Some(vis.to_string());
     }
 
     /// Add a `where` bound to the type definition.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the bound.
     /// * `ty` - The type of the bound.
-    pub fn bound<T>(&mut self, name: &str, ty: T)
-    where
-        T: Into<Type>,
-    {
+    pub fn bound(&mut self, name: &str, ty: impl Into<Type>) {
         self.bounds.push(Bound {
             name: name.to_string(),
             bound: vec![ty.into()],
@@ -72,56 +69,56 @@ impl TypeDef {
     }
 
     /// Add a macro to the type definition (e.g. `"#[async_trait]"`)
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `macro` - The macro to add.
     pub fn r#macro(&mut self, r#macro: &str) {
         self.macros.push(r#macro.to_string());
     }
 
     /// Adds documentation to the type definition.
-    /// 
+    ///
     /// * `docs` - The docs to add.
-    /// 
+    ///
     /// # Examples
     pub fn doc(&mut self, docs: &str) {
         self.docs = Some(Docs::new(docs));
     }
 
     /// Add a new type that the type definition. should derive.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the derive.
-    /// 
+    ///
     /// # Examples
     pub fn derive(&mut self, name: &str) {
         self.derive.push(name.to_string());
     }
 
     /// Specify lint attribute to supress a warning or error.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `allow` - The lint attribute to apply.
     pub fn allow(&mut self, allow: &str) {
         self.allow.push(allow.to_string());
     }
 
     /// Specify representation.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `repr` - The representation to specify.
     pub fn repr(&mut self, repr: &str) {
         self.repr = Some(repr.to_string());
     }
 
     /// Formats the type definition using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
     pub fn fmt_head(
         &self,
@@ -163,35 +160,35 @@ impl TypeDef {
     }
 
     /// Formats the allow using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
     fn fmt_allow(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for allow in &self.allow {
-            write!(fmt, "#[allow({})]\n", allow)?;
+            writeln!(fmt, "#[allow({})]", allow)?;
         }
 
         Ok(())
     }
 
     /// Formats the representation using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
     fn fmt_repr(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         if let Some(ref repr) = self.repr {
-            write!(fmt, "#[repr({})]\n", repr)?;
+            writeln!(fmt, "#[repr({})]", repr)?;
         }
 
         Ok(())
     }
 
     /// Formats the derive using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
     fn fmt_derive(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         if !self.derive.is_empty() {
@@ -204,20 +201,20 @@ impl TypeDef {
                 write!(fmt, "{}", name)?;
             }
 
-            write!(fmt, ")]\n")?;
+            writeln!(fmt, ")]")?;
         }
 
         Ok(())
     }
 
     /// Formats the macros using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
     fn fmt_macros(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         for m in self.macros.iter() {
-            write!(fmt, "{}\n", m)?;
+            writeln!(fmt, "{}", m)?;
         }
         Ok(())
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -16,16 +16,16 @@ pub struct Variant {
 
 impl Variant {
     /// Return a new enum variant with the given name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the enum variant.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Variant;
-    /// 
+    ///
     /// let foo_variant = Variant::new("Foo");
     /// ```
     pub fn new(name: &str) -> Self {
@@ -36,39 +36,36 @@ impl Variant {
     }
 
     /// Add a named field to the variant.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the field.
     /// * `ty` - The type of the field.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Variant;
-    /// 
+    ///
     /// let mut foo_variant = Variant::new("Foo");
     /// foo_variant.named("Bar", "String");
     /// ```
-    pub fn named<T>(&mut self, name: &str, ty: T) -> &mut Self
-    where
-        T: Into<Type>,
-    {
+    pub fn named(&mut self, name: &str, ty: impl Into<Type>) -> &mut Self {
         self.fields.named(name, ty);
         self
     }
 
     /// Add a tuple field to the variant.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `ty` - The type of the tuple.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::Variant;
-    /// 
+    ///
     /// let mut foo_variant = Variant::new("Foo");
     /// foo_variant.tuple("i32");
     /// ```
@@ -78,26 +75,26 @@ impl Variant {
     }
 
     /// Formats the variant using the given formatter.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `fmt` - The formatter to use.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use rust_codegen::{Formatter,Variant};
-    /// 
+    ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
-    /// 
+    ///
     /// let mut foo_variant = Variant::new("Foo");
     /// foo_variant.fmt(&mut fmt);
     /// ```
     pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}", self.name)?;
         self.fields.fmt(fmt)?;
-        write!(fmt, ",\n")?;
+        writeln!(fmt, ",")?;
 
         Ok(())
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -4,6 +4,7 @@ use crate::fields::Fields;
 use crate::formatter::Formatter;
 
 use crate::r#type::Type;
+use crate::FormatCode;
 
 /// Defines an enum variant.
 #[derive(Debug, Clone)]
@@ -73,7 +74,9 @@ impl Variant {
         self.fields.tuple(ty);
         self
     }
+}
 
+impl FormatCode for Variant {
     /// Formats the variant using the given formatter.
     ///
     /// # Arguments
@@ -83,17 +86,17 @@ impl Variant {
     /// # Examples
     ///
     /// ```
-    /// use rust_codegen::{Formatter,Variant};
+    /// use rust_codegen::*;
     ///
     /// let mut dest = String::new();
     /// let mut fmt = Formatter::new(&mut dest);
     ///
     /// let mut foo_variant = Variant::new("Foo");
-    /// foo_variant.fmt(&mut fmt);
+    /// foo_variant.fmt_code(&mut fmt);
     /// ```
-    pub fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_code(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}", self.name)?;
-        self.fields.fmt(fmt)?;
+        self.fields.fmt_code(fmt)?;
         writeln!(fmt, ",")?;
 
         Ok(())


### PR DESCRIPTION
This PR adds compatibility between the custom Formatter and the Display trait.
It depends on:
- #3 

Some rather big changes had to be made for this
- `TypeDef` doesn't support this, as its `fmt_head` requires extra params
- Function has a new field, `is_trait`, for handling whether its in a trait or not. It has a new pub(crate) method `set_trait` which sets this to true. Checks for visibility are done earlier than "fmt"
- Formatter takes a `dyn Write` instead of a `String`
- A new Trait `FormatCode` is used for individual `fmt` implementations
- `fmt` has been renamed to `fmt_code` to bypass annoying collision with std
- A macro is used to implement Display on types, which passes the `std::fmt::Formatter` to our `Formatter` (as it implements Write)
- The `Write` implementation of our `Formatter` has been changed to support that the underlying buffer is not readable anymore
- `Item` now implements `FormatCode` instead of being handled in `Scope`s implementation

I can fully understand if this is too complex of a change, but its a very nice QoL improvement.

All tests pass without any modifications required.